### PR TITLE
integration_test.dart file does not exist/missing

### DIFF
--- a/module02-tourismandco/lesson10/integration_test/app_test.dart
+++ b/module02-tourismandco/lesson10/integration_test/app_test.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:integration_test/integration_test.dart';
 import 'package:lesson10/app.dart';
 import 'package:lesson10/mocks/mock_location.dart';
 


### PR DESCRIPTION
integration_test.dart file does not exist and is missing, is that necessary? . Also if we follow the instructions on the video lesson 10. It shows that app_test.dart is actually in lib/test/integration which is a different file path. 

import 'package:integration_test/integration_test.dart'; remove